### PR TITLE
perf(embedded-tests): reduce auto scaler ingestion wait

### DIFF
--- a/embedded-tests/src/test/java/org/apache/druid/testing/embedded/indexing/autoscaler/CostBasedAutoScalerIntegrationTest.java
+++ b/embedded-tests/src/test/java/org/apache/druid/testing/embedded/indexing/autoscaler/CostBasedAutoScalerIntegrationTest.java
@@ -259,13 +259,13 @@ public class CostBasedAutoScalerIntegrationTest extends StreamIndexTestBase
         .minScaleDownDelay(Duration.standardSeconds(1))
         .build();
 
-    // taskDuration of 10s gives enough time to auto-scaler to fetch task metrics
+    // Keep task duration short so all generated segments can be published promptly while the auto-scaler observes them.
     final SupervisorSpec supervisor = createKafkaSupervisor(kafkaServer)
         .withTuningConfig(t -> t.withMaxRowsPerSegment(maxRowsPerSegment))
         .withIoConfig(
             ioConfig -> ioConfig
                 .withTaskCount(1)
-                .withTaskDuration(Period.seconds(10))
+                .withTaskDuration(Period.seconds(1))
                 .withSupervisorRunPeriod(Period.millis(10))
                 .withAutoScalerConfig(autoScalerConfig)
         )


### PR DESCRIPTION
## Summary

- Reduce the task duration in `CostBasedAutoScalerIntegrationTest#test_autoScaler_scalesUpAndDown_withSlowPublish` from 10 seconds to 1 second.
- Keep the same 10,000-record payload, Kafka topic/partition setup, scale-up and scale-down events, published-row assertion, segment-availability check, SQL count, and task-failure validation.
- This removes an avoidable publication delay from the shared embedded-test fixture; it does not alter the autoscaler configuration or production code.

## Evidence

The CI timing export from run [32339940988](https://github.com/apache/druid/actions/runs/32339940988?pr=20087) identified this test as the slowest test in shard C at **137.774s**.

An isolated unmodified run on the same branch measured **176.50s Surefire / 217.84s Maven wall time**. Temporary phase markers showed that publishing took 0.9s and scale-up detection took 14.5s, while waiting for all 10,000 rows to be published took 139.0s.

Two passing runs with the 1-second task duration measured:

| Run | Surefire | Maven wall |
| --- | ---: | ---: |
| 1 | 79.33s | 104.50s |
| 2 | 71.11s | 96.86s |
| Average | 75.22s | 100.68s |

Compared with the unmodified baseline, the optimized average saves **101.28s / 57.4% Surefire time** and **117.16s / 53.8% Maven wall time**. The Surefire range across the two passing optimized runs is 8.22s; both runs preserved the 10,000-record and scale-up/scale-down assertions.

The complete affected class passed with **5 tests, 0 failures, 0 errors, and 0 skips** in **106.2s Surefire / 131.37s Maven wall time**.

## Validation

- `mvn -ntp test -pl embedded-tests -am -Dtest=org.apache.druid.testing.embedded.indexing.autoscaler.CostBasedAutoScalerIntegrationTest#test_autoScaler_scalesUpAndDown_withSlowPublish -Dsurefire.failIfNoSpecifiedTests=false -Pskip-static-checks -Dweb.console.skip=true -T1C` (two passing runs)
- `mvn -ntp test -pl embedded-tests -am -Dtest=org.apache.druid.testing.embedded.indexing.autoscaler.CostBasedAutoScalerIntegrationTest -Dsurefire.failIfNoSpecifiedTests=false -Pskip-static-checks -Dweb.console.skip=true -T1C`
- `mvn -ntp verify -pl embedded-tests -am -DskipTests -Dweb.console.skip=true -T1C`
- `mvn -ntp com.github.spotbugs:spotbugs-maven-plugin:4.10.2.0:check -pl embedded-tests -DskipTests -Dweb.console.skip=true`
- `git diff --check`

Part of #13948.
