### PR TITLE
perf(processing): cache frame writer expected rows

### DIFF
--- a/processing/src/test/java/org/apache/druid/frame/write/FrameWriterTest.java
+++ b/processing/src/test/java/org/apache/druid/frame/write/FrameWriterTest.java
@@ -75,8 +75,10 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
@@ -360,6 +362,7 @@ public class FrameWriterTest extends InitializedNullHandlingTest
     int allocatorSize = 0;
 
     Pair<Frame, Integer> writeResult;
+    final Map<Integer, List<List<Object>>> expectedRowsByCount = new HashMap<>();
 
     do {
       allocatorMemory.limit(allocatorSize);
@@ -374,8 +377,13 @@ public class FrameWriterTest extends InitializedNullHandlingTest
         if (writeResult.rhs > 0 && writeResult.rhs < totalRows) {
           didWritePartial = true;
 
+          // Keep checking every allocator capacity, but sort each distinct partial row set only once.
+          final List<List<Object>> expectedRows = expectedRowsByCount.computeIfAbsent(
+              rowsWritten,
+              rowCount -> sortIfNeeded(rowSequence.limit(rowCount), signature, sortColumns).toList()
+          );
           verifyFrame(
-              sortIfNeeded(rowSequence.limit(rowsWritten), signature, sortColumns),
+              Sequences.simple(expectedRows),
               writeResult.lhs,
               signature
           );


### PR DESCRIPTION
## Summary

- Cache the sorted expected rows by `rowsWritten` in `FrameWriterTest#test_insufficientWriteCapacity`.
- Continue testing every allocator capacity and verifying every produced partial frame; only repeated sorting of the same expected partial row set is avoided.
- No production code, frame payload, row ordering, allocator boundaries, or failure assertions were changed.

## Evidence

The CI timing export from run [32339940988](https://github.com/apache/druid/actions/runs/32339940988?pr=20087) identified two `FrameWriterTest#test_insufficientWriteCapacity` invocations in shard T,F,G,J at **79.462s** and **76.832s**.

The complete unmodified parameterized method passed 3 applicable contexts locally in **70.95s Surefire / 90.09s Maven wall time**. Temporary timing counters showed a worst context tried 25,393 allocator capacities and performed 16,480 partial-frame checks; sorting expected rows consumed 30.596s while frame verification consumed 1.225s.

Two passing optimized runs of the same parameterized method measured:

| Run | Surefire | Maven wall |
| --- | ---: | ---: |
| 1 | 10.69s | 24.55s |
| 2 | 10.36s | 15.20s |
| Average | 10.525s | 19.875s |

Compared with the unmodified local baseline, the optimized average saves **60.425s / 85.2% Surefire time** and **70.215s / 77.9% Maven wall time**. Both runs passed all 3 applicable contexts.

The complete `FrameWriterTest` class also passed **535 tests, 0 failures, 0 errors, and 0 skips** in **11.81s Surefire / 16.67s Maven wall time**.

## Validation

- `mvn -ntp test -pl processing -am -Dtest=org.apache.druid.frame.write.FrameWriterTest#test_insufficientWriteCapacity -Dsurefire.failIfNoSpecifiedTests=false -Pskip-static-checks -Dweb.console.skip=true -T1C` (two passing runs)
- `mvn -ntp test -pl processing -am -Dtest=org.apache.druid.frame.write.FrameWriterTest -Dsurefire.failIfNoSpecifiedTests=false -Pskip-static-checks -Dweb.console.skip=true -T1C`
- `mvn -ntp verify -pl processing -am -DskipTests -Dweb.console.skip=true -T1C`
- `mvn -ntp com.github.spotbugs:spotbugs-maven-plugin:4.10.2.0:check -pl processing -DskipTests -Dweb.console.skip=true`
- `git diff --check`

Part of #13948.
