### PR TITLE
perf(indexing-service): reduce serial task polling latency

### DIFF
--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/AbstractParallelIndexSupervisorTaskTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/AbstractParallelIndexSupervisorTaskTest.java
@@ -265,6 +265,7 @@ public class AbstractParallelIndexSupervisorTaskTest extends IngestionTestBase
                               .withPartitionsSpec(partitionsSpec)
                               .withForceGuaranteedRollup(forceGuaranteedRollup)
                               .withMaxNumConcurrentSubTasks(maxNumConcurrentSubTasks)
+                              .withTaskStatusCheckPeriodMs(maxNumConcurrentSubTasks == 1 ? 100L : null)
                               .withMaxParseExceptions(5)
                               .build();
   }


### PR DESCRIPTION
## Summary

- Reduce the polling interval used by serial parallel-index supervisor test tasks.
- Keep the existing default polling interval for tests that run multiple concurrent subtasks.
- Preserve task payloads, ordering, partitioning, transaction boundaries, retry injection, and failure detection.

## Evidence

The baseline CI timing data came from the R/B/Q/V shard in run [#20087](https://github.com/apache/druid/actions/runs/32339940988), artifact `unit-test-reports-jdk25-f7b3ee25`.

The selected shard's slowest tests included:

| Test | CI time |
| --- | ---: |
| `RangePartitionMultiPhaseParallelIndexingTest[4]#createsCorrectRangePartitions` | 47.820s |
| `RangePartitionMultiPhaseParallelIndexingTest[4]#testAppendLinearlyPartitionedSegmentsToHashPartitionedDatasourceSuccessfullyAppend` | 33.028s |
| `RangePartitionAdjustingCorePartitionSizeTest[2]#testEqualNumberOfPartitionsToBuckets` | 25.864s |
| `QueryVirtualStorageTest#testQueryPartials` | 21.267s |

The first three tests use a single concurrent subtask and were dominated by the test supervisor's 1-second status polling interval while waiting for short-lived tasks and retry/failure events. The fourth test has a different workload: it performs 1,000 ordered SQL queries and was not changed by this PR.

## Local measurement

The isolated fourth range-partition case passed with the unmodified harness in 56.77s Surefire time and 68.13s Maven wall time.

With this change, the same case passed twice:

| Run | Surefire | Maven wall |
| --- | ---: | ---: |
| 1 | 12.03s | 23.46s |
| 2 | 12.34s | 19.97s |
| Average | 12.185s | 21.715s |

That is a reduction of 44.585s (78.5%) in Surefire time and 46.415s (68.1%) in Maven wall time. The optimized Surefire range was 0.31s. The tests still exercised the existing transient task failures and retries.

The complete affected classes also passed:

- `RangePartitionMultiPhaseParallelIndexingTest`: 10 tests passed, 0 failures/errors/skips, 90.91s Surefire / 102.08s Maven wall.
- `RangePartitionAdjustingCorePartitionSizeTest`: 6 tests passed, 0 failures/errors/skips, 53.34s Surefire / 60.61s Maven wall.

## Validation

- `mvn -ntp test-compile -pl indexing-service -am -Pskip-static-checks -Dweb.console.skip=true -T1C`
- Checkstyle for `indexing-service` and dependencies
- SpotBugs for `indexing-service` and dependencies
- `git diff --check`

All passed.

Part of #13948.
