### PR TITLE
perf(test): combine measured test performance improvements

### DIFF
--- a/embedded-tests/src/test/java/org/apache/druid/testing/embedded/compact/AutoCompactionTest.java
+++ b/embedded-tests/src/test/java/org/apache/druid/testing/embedded/compact/AutoCompactionTest.java
@@ -217,7 +217,9 @@ public class AutoCompactionTest extends CompactionTestBase
                                .addExtension(SketchModule.class)
                                .addExtension(HllSketchModule.class)
                                .addExtension(DoublesSketchModule.class)
-                               .addServer(overlord)
+                               .addServer(
+                                   overlord.addProperty("druid.manager.segments.pollDuration", "PT1S")
+                               )
                                .addServer(coordinator)
                                .addServer(broker)
                                .addServer(new EmbeddedIndexer().addProperty("druid.worker.capacity", "10").setServerMemory(2_000_000_000L))

--- a/embedded-tests/src/test/java/org/apache/druid/testing/embedded/compact/AutoCompactionTest.java
+++ b/embedded-tests/src/test/java/org/apache/druid/testing/embedded/compact/AutoCompactionTest.java
@@ -217,6 +217,7 @@ public class AutoCompactionTest extends CompactionTestBase
                                .addExtension(SketchModule.class)
                                .addExtension(HllSketchModule.class)
                                .addExtension(DoublesSketchModule.class)
+                               // Shorten segment polling for this test so it does not wait for the production interval.
                                .addServer(
                                    overlord.addProperty("druid.manager.segments.pollDuration", "PT1S")
                                )

--- a/embedded-tests/src/test/java/org/apache/druid/testing/embedded/indexing/autoscaler/CostBasedAutoScalerIntegrationTest.java
+++ b/embedded-tests/src/test/java/org/apache/druid/testing/embedded/indexing/autoscaler/CostBasedAutoScalerIntegrationTest.java
@@ -259,13 +259,13 @@ public class CostBasedAutoScalerIntegrationTest extends StreamIndexTestBase
         .minScaleDownDelay(Duration.standardSeconds(1))
         .build();
 
-    // taskDuration of 10s gives enough time to auto-scaler to fetch task metrics
+    // Keep task duration short so all generated segments can be published promptly while the auto-scaler observes them.
     final SupervisorSpec supervisor = createKafkaSupervisor(kafkaServer)
         .withTuningConfig(t -> t.withMaxRowsPerSegment(maxRowsPerSegment))
         .withIoConfig(
             ioConfig -> ioConfig
                 .withTaskCount(1)
-                .withTaskDuration(Period.seconds(10))
+                .withTaskDuration(Period.seconds(1))
                 .withSupervisorRunPeriod(Period.millis(10))
                 .withAutoScalerConfig(autoScalerConfig)
         )

--- a/embedded-tests/src/test/java/org/apache/druid/testing/embedded/kinesis/KinesisResource.java
+++ b/embedded-tests/src/test/java/org/apache/druid/testing/embedded/kinesis/KinesisResource.java
@@ -37,7 +37,9 @@ import software.amazon.awssdk.services.kinesis.model.CreateStreamRequest;
 import software.amazon.awssdk.services.kinesis.model.DeleteStreamRequest;
 import software.amazon.awssdk.services.kinesis.model.DescribeStreamRequest;
 import software.amazon.awssdk.services.kinesis.model.DescribeStreamResponse;
-import software.amazon.awssdk.services.kinesis.model.PutRecordRequest;
+import software.amazon.awssdk.services.kinesis.model.PutRecordsRequest;
+import software.amazon.awssdk.services.kinesis.model.PutRecordsRequestEntry;
+import software.amazon.awssdk.services.kinesis.model.PutRecordsResponse;
 import software.amazon.awssdk.services.kinesis.model.ScalingType;
 import software.amazon.awssdk.services.kinesis.model.Shard;
 import software.amazon.awssdk.services.kinesis.model.StreamDescription;
@@ -49,6 +51,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 /**
@@ -59,6 +62,7 @@ import java.util.stream.Collectors;
 public class KinesisResource extends StreamIngestResource<LocalStackContainer>
 {
   private static final String IMAGE = "localstack/localstack:4.13.1";
+  private static final int PUT_RECORDS_BATCH_SIZE = 500;
 
   private KinesisClient kinesisClient;
 
@@ -153,15 +157,7 @@ public class KinesisResource extends StreamIngestResource<LocalStackContainer>
   @Override
   public void publishRecordsToTopic(String topic, List<byte[]> records)
   {
-    for (byte[] record : records) {
-      kinesisClient.putRecord(
-          PutRecordRequest.builder()
-                          .streamName(topic)
-                          .partitionKey(DigestUtils.sha1Hex(record))
-                          .data(SdkBytes.fromByteArray(record))
-                          .build()
-      );
-    }
+    publishRecordsInBatches(topic, records, record -> DigestUtils.sha1Hex(record));
   }
 
   @Override
@@ -178,14 +174,33 @@ public class KinesisResource extends StreamIngestResource<LocalStackContainer>
 
   public void publishRecordsToTopicPartition(String topic, String partitionKey, List<byte[]> records)
   {
-    for (byte[] record : records) {
-      kinesisClient.putRecord(
-          PutRecordRequest.builder()
-                          .streamName(topic)
-                          .partitionKey(partitionKey)
-                          .data(SdkBytes.fromByteArray(record))
-                          .build()
+    publishRecordsInBatches(topic, records, record -> partitionKey);
+  }
+
+  private void publishRecordsInBatches(
+      String topic,
+      List<byte[]> records,
+      Function<byte[], String> partitionKeyFunction
+  )
+  {
+    for (int start = 0; start < records.size(); start += PUT_RECORDS_BATCH_SIZE) {
+      final List<PutRecordsRequestEntry> entries = records.subList(
+          start,
+          Math.min(start + PUT_RECORDS_BATCH_SIZE, records.size())
+      ).stream().map(record -> PutRecordsRequestEntry.builder()
+                                                       .partitionKey(partitionKeyFunction.apply(record))
+                                                       .data(SdkBytes.fromByteArray(record))
+                                                       .build())
+                  .collect(Collectors.toList());
+      final PutRecordsResponse response = kinesisClient.putRecords(
+          PutRecordsRequest.builder()
+                           .streamName(topic)
+                           .records(entries)
+                           .build()
       );
+      if (response.failedRecordCount() > 0) {
+        throw new IllegalStateException("Failed to publish " + response.failedRecordCount() + " Kinesis records");
+      }
     }
   }
 

--- a/embedded-tests/src/test/java/org/apache/druid/testing/embedded/kinesis/KinesisResource.java
+++ b/embedded-tests/src/test/java/org/apache/druid/testing/embedded/kinesis/KinesisResource.java
@@ -62,6 +62,7 @@ import java.util.stream.Collectors;
 public class KinesisResource extends StreamIngestResource<LocalStackContainer>
 {
   private static final String IMAGE = "localstack/localstack:4.13.1";
+  // Kinesis PutRecords accepts at most 500 records in a single request.
   private static final int PUT_RECORDS_BATCH_SIZE = 500;
 
   private KinesisClient kinesisClient;

--- a/embedded-tests/src/test/java/org/apache/druid/testing/embedded/msq/MSQWorkerFaultToleranceTest.java
+++ b/embedded-tests/src/test/java/org/apache/druid/testing/embedded/msq/MSQWorkerFaultToleranceTest.java
@@ -94,7 +94,7 @@ public class MSQWorkerFaultToleranceTest extends EmbeddedClusterTestBase
     final EmbeddedIndexer faultyIndexer = new EmbeddedIndexer()
         .addProperty("druid.plaintextPort", "7091")
         .addProperty("druid.unsafe.cluster.testing", "true")
-        .addProperty("druid.unsafe.cluster.testing.overlordClient.taskStatusDelay", "PT1H")
+        .addProperty("druid.unsafe.cluster.testing.overlordClient.taskStatusDelay", "PT1S")
         .addProperty("druid.worker.capacity", "1");
     cluster.addServer(faultyIndexer);
     faultyIndexer.start();

--- a/embedded-tests/src/test/java/org/apache/druid/testing/embedded/msq/MSQWorkerFaultToleranceTest.java
+++ b/embedded-tests/src/test/java/org/apache/druid/testing/embedded/msq/MSQWorkerFaultToleranceTest.java
@@ -94,6 +94,7 @@ public class MSQWorkerFaultToleranceTest extends EmbeddedClusterTestBase
     final EmbeddedIndexer faultyIndexer = new EmbeddedIndexer()
         .addProperty("druid.plaintextPort", "7091")
         .addProperty("druid.unsafe.cluster.testing", "true")
+        // Keep the injected delay short so the retry path is exercised without a one-hour wait.
         .addProperty("druid.unsafe.cluster.testing.overlordClient.taskStatusDelay", "PT1S")
         .addProperty("druid.worker.capacity", "1");
     cluster.addServer(faultyIndexer);

--- a/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/KafkaRecordSupplierTest.java
+++ b/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/KafkaRecordSupplierTest.java
@@ -29,6 +29,7 @@ import org.apache.druid.data.input.kafka.KafkaTopicPartition;
 import org.apache.druid.indexing.kafka.supervisor.KafkaSupervisorIOConfig;
 import org.apache.druid.indexing.kafka.test.EmbeddedKafkaBroker;
 import org.apache.druid.indexing.seekablestream.common.OrderedPartitionableRecord;
+import org.apache.druid.indexing.seekablestream.common.StreamException;
 import org.apache.druid.indexing.seekablestream.common.StreamPartition;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.emitter.service.ServiceMetricEvent;
@@ -647,34 +648,31 @@ public class KafkaRecordSupplierTest
   }
 
   @Test
-  public void testSeekUnassigned()
+  public void testSeekUnassigned() throws ExecutionException, InterruptedException
   {
-    assertThrows(IllegalStateException.class, () -> {
-      // Insert data
-      try (final KafkaProducer<byte[], byte[]> kafkaProducer = KAFKA_SERVER.newProducer()) {
-        for (ProducerRecord<byte[], byte[]> record : records) {
-          kafkaProducer.send(record).get();
-        }
-      }
+    insertData();
 
-      StreamPartition<KafkaTopicPartition> partition0 = StreamPartition.of(TOPIC, PARTITION_0);
-      StreamPartition<KafkaTopicPartition> partition1 = StreamPartition.of(TOPIC, PARTITION_1);
+    final StreamPartition<KafkaTopicPartition> partition0 = StreamPartition.of(TOPIC, PARTITION_0);
+    final StreamPartition<KafkaTopicPartition> partition1 = StreamPartition.of(TOPIC, PARTITION_1);
+    final Set<StreamPartition<KafkaTopicPartition>> partitions = ImmutableSet.of(
+        StreamPartition.of(TOPIC, PARTITION_0)
+    );
+    final KafkaRecordSupplier recordSupplier = new KafkaRecordSupplier(
+        KAFKA_SERVER.consumerProperties(), OBJECT_MAPPER, null, false, null);
 
-      Set<StreamPartition<KafkaTopicPartition>> partitions = ImmutableSet.of(
-          StreamPartition.of(TOPIC, PARTITION_0)
-      );
-
-      KafkaRecordSupplier recordSupplier = new KafkaRecordSupplier(
-          KAFKA_SERVER.consumerProperties(), OBJECT_MAPPER, null, false, null);
-
+    try {
       recordSupplier.assign(partitions);
-
+      recordSupplier.seekToEarliest(Collections.singleton(partition0));
       Assertions.assertEquals(0, (long) recordSupplier.getEarliestSequenceNumber(partition0));
-
-      recordSupplier.seekToEarliest(Collections.singleton(partition1));
-
+      final StreamException exception = Assertions.assertThrows(
+          StreamException.class,
+          () -> recordSupplier.seekToEarliest(Collections.singleton(partition1))
+      );
+      Assertions.assertInstanceOf(IllegalStateException.class, exception.getCause());
+    }
+    finally {
       recordSupplier.close();
-    });
+    }
   }
 
   @Test

--- a/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/supervisor/KafkaSupervisorTest.java
+++ b/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/supervisor/KafkaSupervisorTest.java
@@ -5658,7 +5658,7 @@ public class KafkaSupervisorTest extends EasyMockSupport
                   null,
                   StringUtils.toUtf8(StringUtils.format("event-%d", j))
               )
-          ).get();
+          );
           time = time.plus(5, ChronoUnit.SECONDS);
         }
       }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/AbstractParallelIndexSupervisorTaskTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/AbstractParallelIndexSupervisorTaskTest.java
@@ -251,6 +251,7 @@ public class AbstractParallelIndexSupervisorTaskTest extends IngestionTestBase
                               .withPartitionsSpec(partitionsSpec)
                               .withForceGuaranteedRollup(forceGuaranteedRollup)
                               .withMaxNumConcurrentSubTasks(maxNumConcurrentSubTasks)
+                              .withTaskStatusCheckPeriodMs(maxNumConcurrentSubTasks == 1 ? 100L : null)
                               .withMaxParseExceptions(5)
                               .build();
   }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/AbstractParallelIndexSupervisorTaskTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/AbstractParallelIndexSupervisorTaskTest.java
@@ -251,6 +251,7 @@ public class AbstractParallelIndexSupervisorTaskTest extends IngestionTestBase
                               .withPartitionsSpec(partitionsSpec)
                               .withForceGuaranteedRollup(forceGuaranteedRollup)
                               .withMaxNumConcurrentSubTasks(maxNumConcurrentSubTasks)
+                              // Serial tests need only a short poll interval; concurrent tests retain the default.
                               .withTaskStatusCheckPeriodMs(maxNumConcurrentSubTasks == 1 ? 100L : null)
                               .withMaxParseExceptions(5)
                               .build();

--- a/processing/src/test/java/org/apache/druid/frame/write/FrameWriterTest.java
+++ b/processing/src/test/java/org/apache/druid/frame/write/FrameWriterTest.java
@@ -75,8 +75,10 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
@@ -360,6 +362,7 @@ public class FrameWriterTest extends InitializedNullHandlingTest
     int allocatorSize = 0;
 
     Pair<Frame, Integer> writeResult;
+    final Map<Integer, List<List<Object>>> expectedRowsByCount = new HashMap<>();
 
     do {
       allocatorMemory.limit(allocatorSize);
@@ -374,8 +377,13 @@ public class FrameWriterTest extends InitializedNullHandlingTest
         if (writeResult.rhs > 0 && writeResult.rhs < totalRows) {
           didWritePartial = true;
 
+          // Keep checking every allocator capacity, but sort each distinct partial row set only once.
+          final List<List<Object>> expectedRows = expectedRowsByCount.computeIfAbsent(
+              rowsWritten,
+              rowCount -> sortIfNeeded(rowSequence.limit(rowCount), signature, sortColumns).toList()
+          );
           verifyFrame(
-              sortIfNeeded(rowSequence.limit(rowsWritten), signature, sortColumns),
+              Sequences.simple(expectedRows),
               writeResult.lhs,
               signature
           );

--- a/processing/src/test/java/org/apache/druid/indexer/granularity/UniformGranularityTest.java
+++ b/processing/src/test/java/org/apache/druid/indexer/granularity/UniformGranularityTest.java
@@ -22,7 +22,6 @@ package org.apache.druid.indexer.granularity;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Iterators;
 import com.google.common.collect.Lists;
 import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.java.util.common.DateTimes;
@@ -323,9 +322,9 @@ public class UniformGranularityTest
 
     Assertions.assertNotNull(spec);
 
-    int count = Iterators.size(spec.sortedBucketIntervals().iterator());
-    // account for three leap years...
-    Assertions.assertEquals(3600 * 24 * 365 * 10 + 3 * 24 * 3600, count);
+    // The constructor keeps this iterator lazy. Read one bucket to exercise the lazy path without traversing
+    // 315,619,200 one-second buckets solely to count them.
+    Assertions.assertTrue(spec.sortedBucketIntervals().iterator().hasNext());
   }
 
   private void notEqualsCheck(GranularitySpec spec1, GranularitySpec spec2)

--- a/processing/src/test/java/org/apache/druid/indexer/granularity/UniformGranularityTest.java
+++ b/processing/src/test/java/org/apache/druid/indexer/granularity/UniformGranularityTest.java
@@ -22,6 +22,7 @@ package org.apache.druid.indexer.granularity;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterators;
 import com.google.common.collect.Lists;
 import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.java.util.common.DateTimes;
@@ -322,9 +323,9 @@ public class UniformGranularityTest
 
     Assertions.assertNotNull(spec);
 
-    // The constructor keeps this iterator lazy. Read one bucket to exercise the lazy path without traversing
-    // 315,619,200 one-second buckets solely to count them.
-    Assertions.assertTrue(spec.sortedBucketIntervals().iterator().hasNext());
+    int count = Iterators.size(spec.sortedBucketIntervals().iterator());
+    // account for three leap years...
+    Assertions.assertEquals(3600 * 24 * 365 * 10 + 3 * 24 * 3600, count);
   }
 
   private void notEqualsCheck(GranularitySpec spec1, GranularitySpec spec2)

--- a/processing/src/test/java/org/apache/druid/segment/MergingRowIteratorTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/MergingRowIteratorTest.java
@@ -106,28 +106,37 @@ public class MergingRowIteratorTest extends InitializedNullHandlingTest
   {
     String message = Stream.of(timestampSequences).map(List::toString).collect(Collectors.joining(" "));
     int totalLength = Stream.of(timestampSequences).mapToInt(List::size).sum();
+    List<Long> expectedTimestamps = new ArrayList<>();
+    Iterator<Long> expectedTimestampIterator = Utils.mergeSorted(
+        Stream.of(timestampSequences).map(List::iterator).collect(Collectors.toList()),
+        Comparator.naturalOrder()
+    );
+    while (expectedTimestampIterator.hasNext()) {
+      expectedTimestamps.add(expectedTimestampIterator.next());
+    }
     for (int markIteration = 0; markIteration < totalLength; markIteration++) {
-      testMerge(message, markIteration, timestampSequences);
+      testMerge(message, markIteration, expectedTimestamps, timestampSequences);
     }
   }
 
   @SafeVarargs
-  private static void testMerge(String message, int markIteration, List<Long>... timestampSequences)
+  private static void testMerge(
+      String message,
+      int markIteration,
+      List<Long> expectedTimestamps,
+      List<Long>... timestampSequences
+  )
   {
     try (MergingRowIterator mergingRowIterator = new MergingRowIterator(
         Stream.of(timestampSequences).map(TestRowIterator::new).collect(Collectors.toList())
     )) {
-      Iterator<Long> mergedTimestamps = Utils.mergeSorted(
-          Stream.of(timestampSequences).map(List::iterator).collect(Collectors.toList()),
-          Comparator.naturalOrder()
-      );
       long markedTimestamp = 0;
       long currentTimestamp = 0;
       int i = 0;
       boolean marked = false;
       boolean iterated = false;
-      while (mergedTimestamps.hasNext()) {
-        currentTimestamp = mergedTimestamps.next();
+      for (Long expectedTimestamp : expectedTimestamps) {
+        currentTimestamp = expectedTimestamp;
         Assertions.assertTrue(mergingRowIterator.moveToNext(), message);
         iterated = true;
         Assertions.assertEquals(currentTimestamp, mergingRowIterator.getPointer().timestampSelector.getLong(), message);

--- a/processing/src/test/java/org/apache/druid/segment/MergingRowIteratorTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/MergingRowIteratorTest.java
@@ -106,6 +106,8 @@ public class MergingRowIteratorTest extends InitializedNullHandlingTest
   {
     String message = Stream.of(timestampSequences).map(List::toString).collect(Collectors.joining(" "));
     int totalLength = Stream.of(timestampSequences).mapToInt(List::size).sum();
+    // The expected merge order does not depend on markIteration. Materialize it once per sequence
+    // triple so each mark iteration can focus on rebuilding the production iterator and testing mark handling.
     List<Long> expectedTimestamps = new ArrayList<>();
     Iterator<Long> expectedTimestampIterator = Utils.mergeSorted(
         Stream.of(timestampSequences).map(List::iterator).collect(Collectors.toList()),


### PR DESCRIPTION
## Summary

Combine the measured test-performance improvements into one test-only PR. The changes remove avoidable waits or repeated deterministic work while preserving test payloads, ordering, partitioning, transaction boundaries, retry/failure injection, and assertions.

The optimized durations below are averages of passing local Surefire runs; interrupted or resource-limited runs are excluded. Original durations and improvements are retained for comparison.

## Optimized Surefire durations

| Test | Original Surefire | Optimized average Surefire | Improvement |
| --- | ---: | ---: | ---: |
| `AutoCompactionTest` filtered supervisor tests | 245.171s | **13.863s** | **231.308s / 94.34%** |
| `MSQWorkerFaultToleranceTest#test_cancelledWorker_isRetried_ifFaultToleranceIsEnabled` | 312.000s | **12.845s** | **299.155s / 95.88%** |
| `CostBasedAutoScalerIntegrationTest#test_autoScaler_scalesUpAndDown_withSlowPublish` | 176.500s | **75.220s** | **101.280s / 57.4%** |
| `FrameWriterTest#test_insufficientWriteCapacity` (3 applicable parameter sets) | 70.950s | **10.525s** | **60.425s / 85.2%** |
| `RangePartitionMultiPhaseParallelIndexingTest[4]#createsCorrectRangePartitions` | 56.770s | **12.185s** | **44.585s / 78.5%** |
| `KafkaRecordSupplierTest#testSeekUnassigned` | 125.3s | **5.7s** | **119.6s / 95.5%** |
| `KinesisFaultToleranceTest#test_supervisorRecovers_afterCoordinatorRestart` | 97.6s | **43.0s** | **54.7s / 56.0%** |
| `KinesisFaultToleranceTest#test_supervisorRecovers_afterHistoricalRestart` | 79.0s | **33.7s** | **45.2s / 57.2%** |
| `KinesisFaultToleranceTest#test_supervisorRecovers_afterOverlordRestart` | 94.2s | **39.5s** | **54.7s / 58.1%** |
| `KinesisFaultToleranceTest#test_supervisorRecovers_afterSuspendResume` | 76.4s | **35.3s** | **41.1s / 53.8%** |
| `MergingRowIteratorTest#testAllPossible5ElementSequences` | 53.845s | **35.635s** | **18.210s / 33.8%** |

## Aim and safety notes

- **AutoCompaction:** set the embedded Overlord's test-only segment poll period to `PT1S` instead of the default 60 seconds. This removes scheduler latency; compaction policies, data, task execution, and assertions are unchanged.
- **MSQ fault tolerance:** set the deliberately injected Overlord task-status delay to `PT1S` instead of `PT1H`. The worker cancellation, failed-task metric, relaunch, segment availability, and final SQL assertion remain unchanged; the one-hour delay was only a blocking-wait bottleneck.
- **Cost-based autoscaler:** reduce the test supervisor task duration from 10 seconds to 1 second. The 10,000-record payload, Kafka setup, scale-up/scale-down events, published-row and SQL assertions, and failure detection remain unchanged.
- **FrameWriter:** cache sorted expected rows by `rowsWritten`. Every allocator capacity and partial frame is still verified; only repeated sorting of the same deterministic row set is avoided.
- **Range partition tests:** use a 100ms status polling period only for serial (`maxNumConcurrentSubTasks == 1`) test supervisors. Multi-subtask tests retain the default; task order, partitioning, retries, and failure injection remain unchanged.
- **Kafka record supplier:** prepare records before the expected-exception assertion and assert the `StreamException` contract directly, so setup time is not included in the failure-path wait.
- **Kinesis:** publish at most 500 records per `PutRecords` request, preserving each record and partition key while failing immediately when a batch reports failed records.
- **Kafka supervisor:** remove per-record blocking waits from the producer helper; the transaction commit remains the completion barrier for the offset and partition-update tests.
- **Merging row iterator:** materialize the deterministic expected merged timestamps once per sequence triple and reuse them for all mark positions. The exhaustive sequence combinations, mark positions, production iterator construction, ordering, and assertions remain unchanged.

## Complete affected test classes

These complete-class runs passed after the individual changes:

| Class | Result after change |
| --- | ---: |
| `AutoCompactionTest` | 31 tests, 3 skips, 0 failures/errors |
| `MSQWorkerFaultToleranceTest` | 1 test passed |
| `CostBasedAutoScalerIntegrationTest` | 5 tests, 0 failures/errors/skips |
| `FrameWriterTest` | 535 tests, 0 failures/errors/skips |
| `RangePartitionMultiPhaseParallelIndexingTest` | 10 tests, 0 failures/errors/skips |
| `RangePartitionAdjustingCorePartitionSizeTest` | 6 tests, 0 failures/errors/skips |
| `KafkaRecordSupplierTest#testSeekUnassigned` | passed |
| `KinesisFaultToleranceTest` | 8 tests passed |
| `KafkaSupervisorTest#testLatestOffset`, `#testPartitionIdsUpdates` | passed |
| `MergingRowIteratorTest` | 6 tests, 0 failures/errors/skips (35.78s) |

## Validation

The combined branch was revalidated before publication with:

- `mvn -ntp test-compile -pl embedded-tests,processing,indexing-service -am -Pskip-static-checks -Dweb.console.skip=true -T1C` — passed.
- `mvn -ntp checkstyle:check -pl embedded-tests,processing,indexing-service -am -Dweb.console.skip=true -T1C` — passed with zero Checkstyle violations.
- `mvn -ntp com.github.spotbugs:spotbugs-maven-plugin:4.10.2.0:check -pl processing,indexing-service -am -DskipTests -Dweb.console.skip=true -T1C` — passed with zero SpotBugs bugs or errors.
- Combined focused tests for the six original affected classes — passed: 588 tests, 0 failures, 0 errors, and 3 skips (37 in `embedded-tests`, 535 in `processing`, and 16 in `indexing-service`).
- PR #167 focused tests — passed: `KafkaRecordSupplierTest#testSeekUnassigned`, `KafkaSupervisorTest#testLatestOffset`, `KafkaSupervisorTest#testPartitionIdsUpdates`, and all 8 tests in `KinesisFaultToleranceTest`.
- `MergingRowIteratorTest#testAllPossible5ElementSequences` — passed twice after the change (35.24s and 36.03s Surefire); complete class passed with 6 tests.
- `git diff --check master...HEAD` — passed.

The complete affected classes were also run as part of the focused suite; their results are listed above.
