### PR TITLE
feat(sql): support native queries for sys.supervisors

### DIFF
--- a/docs/querying/sql-metadata-tables.md
+++ b/docs/querying/sql-metadata-tables.md
@@ -169,6 +169,7 @@ execution:
 |Table|Source of rows|
 |-----|--------------|
 |[`sys.tasks`](#tasks-table)|The Overlord that owns task state. Supported filters are pushed into task storage when the configured task storage implementation supports filter pushdown.|
+|[`sys.supervisors`](#supervisors-table)|The leader Overlord that owns active supervisor state. Filters that identify specific supervisors can avoid constructing unrelated supervisor rows.|
 |[`sys.server_properties`](#server_properties-table)|The Druid server processes discovered in the cluster. Filters on `server` and `service_name` can avoid reading properties from nodes that don't match.|
 
 After Druid retrieves the system-table rows, the native engine applies the remaining filters, expressions,

--- a/embedded-tests/src/test/java/org/apache/druid/testing/embedded/query/NativeSysSupervisorsQueryTest.java
+++ b/embedded-tests/src/test/java/org/apache/druid/testing/embedded/query/NativeSysSupervisorsQueryTest.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.testing.embedded.query;
+
+import org.apache.druid.indexing.overlord.supervisor.NoopSupervisorSpec;
+import org.apache.druid.query.QueryContexts;
+import org.apache.druid.sql.calcite.planner.PlannerContext;
+import org.apache.druid.sql.calcite.run.NativeSqlEngine;
+import org.apache.druid.testing.embedded.EmbeddedBroker;
+import org.apache.druid.testing.embedded.EmbeddedCoordinator;
+import org.apache.druid.testing.embedded.EmbeddedDruidCluster;
+import org.apache.druid.testing.embedded.EmbeddedOverlord;
+import org.apache.druid.testing.embedded.junit5.EmbeddedClusterTestBase;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.List;
+import java.util.Map;
+
+public class NativeSysSupervisorsQueryTest extends EmbeddedClusterTestBase
+{
+  private static final String SUPERVISOR_PREFIX = "native_sys_supervisor_";
+
+  @Override
+  protected EmbeddedDruidCluster createCluster()
+  {
+    return EmbeddedDruidCluster.withEmbeddedDerbyAndZookeeper()
+                               .useLatchableEmitter()
+                               .addServer(new EmbeddedCoordinator())
+                               .addServer(new EmbeddedOverlord())
+                               .addServer(new EmbeddedBroker());
+  }
+
+  @BeforeAll
+  public void createSupervisors()
+  {
+    cluster.callApi().postSupervisor(
+        new NoopSupervisorSpec(SUPERVISOR_PREFIX + "a", List.of("native_sys_supervisor_datasource_a"))
+    );
+    cluster.callApi().postSupervisor(
+        new NoopSupervisorSpec(SUPERVISOR_PREFIX + "b", List.of("native_sys_supervisor_datasource_b"))
+    );
+  }
+
+  @ParameterizedTest(name = "plannerStrategy = {0}")
+  @ValueSource(strings = {
+      QueryContexts.NATIVE_QUERY_SQL_PLANNING_MODE_COUPLED,
+      QueryContexts.NATIVE_QUERY_SQL_PLANNING_MODE_DECOUPLED
+  })
+  public void testFilteredGroupByUsesOverlordProvider(final String plannerStrategy)
+  {
+    final String result = cluster.runSql(
+        "SELECT datasource, COUNT(*) "
+        + "FROM sys.supervisors "
+        + "WHERE supervisor_id = '" + SUPERVISOR_PREFIX + "a' "
+        + "GROUP BY datasource",
+        nativeQueryContext(plannerStrategy)
+    );
+
+    Assertions.assertEquals("native_sys_supervisor_datasource_a,1", result);
+  }
+
+  @ParameterizedTest(name = "plannerStrategy = {0}")
+  @ValueSource(strings = {
+      QueryContexts.NATIVE_QUERY_SQL_PLANNING_MODE_COUPLED,
+      QueryContexts.NATIVE_QUERY_SQL_PLANNING_MODE_DECOUPLED
+  })
+  public void testNativeAggregationsSupportDistinctCount(final String plannerStrategy)
+  {
+    final String result = cluster.runSql(
+        "SELECT COUNT(*), COUNT(DISTINCT supervisor_id), COUNT(DISTINCT datasource), SUM(healthy) "
+        + "FROM sys.supervisors "
+        + "WHERE supervisor_id IN ('" + SUPERVISOR_PREFIX + "a', '" + SUPERVISOR_PREFIX + "b')",
+        nativeQueryContext(plannerStrategy)
+    );
+
+    Assertions.assertEquals("2,2,2,2", result);
+  }
+
+  private static Map<String, Object> nativeQueryContext(final String plannerStrategy)
+  {
+    return Map.of(
+        QueryContexts.ENGINE,
+        NativeSqlEngine.NAME,
+        PlannerContext.CTX_USE_NATIVE_QUERY_FOR_SYSTEM_TABLES,
+        true,
+        QueryContexts.CTX_NATIVE_QUERY_SQL_PLANNING_MODE,
+        plannerStrategy
+    );
+  }
+}

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/supervisor/SupervisorResource.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/supervisor/SupervisorResource.java
@@ -21,7 +21,6 @@ package org.apache.druid.indexing.overlord.supervisor;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Function;
 import com.google.common.base.Optional;
@@ -235,42 +234,7 @@ public class SupervisorResource
           if (includeFull || includeState || includeSystem) {
             List<SupervisorStatus> allStates = authorizedSupervisorIds
                 .stream()
-                .map(x -> {
-                  Optional<SupervisorStateManager.State> theState =
-                      manager.getSupervisorState(x);
-                  SupervisorStatus.Builder theBuilder = new SupervisorStatus.Builder();
-                  theBuilder.withId(x);
-                  if (theState.isPresent()) {
-                    theBuilder.withState(theState.get().getBasicState().toString())
-                              .withDetailedState(theState.get().toString())
-                              .withHealthy(theState.get().isHealthy());
-                  }
-                  Optional<SupervisorSpec> theSpec = manager.getSupervisorSpec(x);
-                  if (theSpec.isPresent()) {
-                    final SupervisorSpec spec = theSpec.get();
-                    theBuilder.withDataSource(spec.getDataSources().stream().findFirst().orElse(null));
-                    if (includeFull) {
-                      theBuilder.withSpec(spec);
-                    }
-                    if (includeSystem) {
-                      try {
-                        // serializing SupervisorSpec here, so that callers of `druid/indexer/v1/supervisor?system`
-                        // which are outside the overlord process can deserialize the response and get a json
-                        // payload of SupervisorSpec object when they don't have guice bindings for all the fields
-                        // for example, broker does not have bindings for all fields of `KafkaSupervisorSpec` or
-                        // `KinesisSupervisorSpec`
-                        theBuilder.withSpecString(objectMapper.writeValueAsString(spec));
-                      }
-                      catch (JsonProcessingException e) {
-                        throw new RuntimeException(e);
-                      }
-                      theBuilder.withType(spec.getType())
-                                .withSource(spec.getSource())
-                                .withSuspended(spec.isSuspended());
-                    }
-                  }
-                  return theBuilder.build();
-                })
+                .map(x -> SupervisorStatusMapper.toStatus(objectMapper, manager, x, includeFull, includeSystem))
                 .filter(Objects::nonNull)
                 .collect(Collectors.toList());
             return Response.ok(allStates).build();

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/supervisor/SupervisorStatusMapper.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/supervisor/SupervisorStatusMapper.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.indexing.overlord.supervisor;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Optional;
+
+/** Builds the common supervisor status representation used by the REST API and {@code sys.supervisors}. */
+final class SupervisorStatusMapper
+{
+  private SupervisorStatusMapper()
+  {
+  }
+
+  public static SupervisorStatus toStatus(
+      final ObjectMapper objectMapper,
+      final SupervisorManager manager,
+      final String supervisorId,
+      final boolean includeFull,
+      final boolean includeSystem
+  )
+  {
+    final SupervisorStatus.Builder builder = new SupervisorStatus.Builder().withId(supervisorId);
+    final Optional<SupervisorStateManager.State> state = manager.getSupervisorState(supervisorId);
+    if (state.isPresent()) {
+      builder.withState(state.get().getBasicState().toString())
+             .withDetailedState(state.get().toString())
+             .withHealthy(state.get().isHealthy());
+    }
+
+    final Optional<SupervisorSpec> optionalSpec = manager.getSupervisorSpec(supervisorId);
+    if (optionalSpec.isPresent()) {
+      final SupervisorSpec spec = optionalSpec.get();
+      builder.withDataSource(spec.getDataSources().stream().findFirst().orElse(null));
+      if (includeFull) {
+        builder.withSpec(spec);
+      }
+      if (includeSystem) {
+        try {
+          // Serialize the spec explicitly so consumers do not need bindings for every SupervisorSpec subtype.
+          builder.withSpecString(objectMapper.writeValueAsString(spec));
+        }
+        catch (JsonProcessingException e) {
+          throw new RuntimeException(e);
+        }
+        builder.withType(spec.getType())
+               .withSource(spec.getSource())
+               .withSuspended(spec.isSuspended());
+      }
+    }
+    return builder.build();
+  }
+}

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/supervisor/SupervisorsTableDataProvider.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/supervisor/SupervisorsTableDataProvider.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.indexing.overlord.supervisor;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Optional;
+import com.google.inject.Inject;
+import org.apache.druid.guice.annotations.Json;
+import org.apache.druid.indexing.overlord.TaskMaster;
+import org.apache.druid.query.filter.DimFilter;
+import org.apache.druid.query.filter.EqualityFilter;
+import org.apache.druid.query.filter.InDimFilter;
+import org.apache.druid.query.filter.OrDimFilter;
+import org.apache.druid.query.filter.SelectorDimFilter;
+import org.apache.druid.query.filter.TypedInFilter;
+import org.apache.druid.server.security.AuthenticationResult;
+import org.apache.druid.server.system.SystemTableNotLeaderException;
+import org.apache.druid.server.system.table.SystemTableDataProvider;
+import org.apache.druid.server.system.table.SystemTablePushdownFilter;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/** Native row supplier for {@code sys.supervisors}. */
+public class SupervisorsTableDataProvider implements SystemTableDataProvider
+{
+  private static final String SUPERVISOR_ID_COLUMN = "supervisor_id";
+  private static final List<SystemTablePushdownFilter> PUSHDOWN_FILTERS = List.of(
+      new SystemTablePushdownFilter(SUPERVISOR_ID_COLUMN, null)
+  );
+
+  private final TaskMaster taskMaster;
+  private final ObjectMapper objectMapper;
+
+  @Inject
+  public SupervisorsTableDataProvider(
+      final TaskMaster taskMaster,
+      @Json final ObjectMapper objectMapper
+  )
+  {
+    this.taskMaster = taskMaster;
+    this.objectMapper = objectMapper;
+  }
+
+  @Override
+  public List<SystemTablePushdownFilter> getPushdownFilters()
+  {
+    return PUSHDOWN_FILTERS;
+  }
+
+  @Override
+  public Iterable<Object[]> getRows(
+      final List<DimFilter> filters,
+      final AuthenticationResult internalAuthenticationResult
+  )
+  {
+    final Optional<SupervisorManager> optionalManager = taskMaster.getSupervisorManager();
+    if (!optionalManager.isPresent()) {
+      throw new SystemTableNotLeaderException("overlord");
+    }
+
+    final SupervisorManager manager = optionalManager.get();
+    final Set<String> supervisorIds = filterSupervisorIds(manager.getSupervisorIds(), filters);
+    final List<Object[]> rows = new ArrayList<>(supervisorIds.size());
+    for (final String supervisorId : supervisorIds) {
+      rows.add(toRow(SupervisorStatusMapper.toStatus(objectMapper, manager, supervisorId, false, true)));
+    }
+    return rows;
+  }
+
+  private static Set<String> filterSupervisorIds(
+      final Set<String> allSupervisorIds,
+      final List<DimFilter> filters
+  )
+  {
+    final Set<String> supervisorIds = new HashSet<>(allSupervisorIds);
+    for (final DimFilter filter : filters) {
+      if (isStringValuesFilter(filter)
+          && SUPERVISOR_ID_COLUMN.equals(SystemTablePushdownFilter.getStringValuesColumn(filter))) {
+        supervisorIds.retainAll(SystemTablePushdownFilter.getStringValues(filter));
+      }
+    }
+    return supervisorIds;
+  }
+
+  private static boolean isStringValuesFilter(final DimFilter filter)
+  {
+    return filter instanceof SelectorDimFilter
+           || filter instanceof EqualityFilter
+           || filter instanceof InDimFilter
+           || filter instanceof TypedInFilter
+           || filter instanceof OrDimFilter;
+  }
+
+  private static Object[] toRow(final SupervisorStatus supervisor)
+  {
+    return new Object[]{
+        supervisor.getId(),
+        supervisor.getDataSource(),
+        supervisor.getState(),
+        supervisor.getDetailedState(),
+        supervisor.isHealthy() ? 1L : 0L,
+        supervisor.getType(),
+        supervisor.getSource(),
+        supervisor.isSuspended() ? 1L : 0L,
+        supervisor.getSpecString()
+    };
+  }
+}

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/supervisor/SupervisorsTableDataProviderTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/supervisor/SupervisorsTableDataProviderTest.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.indexing.overlord.supervisor;
+
+import com.google.common.base.Optional;
+import org.apache.druid.indexing.overlord.TaskMaster;
+import org.apache.druid.query.filter.DimFilter;
+import org.apache.druid.query.filter.SelectorDimFilter;
+import org.apache.druid.segment.TestHelper;
+import org.apache.druid.server.security.AuthenticationResult;
+import org.apache.druid.server.system.SystemTableNotLeaderException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+public class SupervisorsTableDataProviderTest
+{
+  @Test
+  public void testReturnsSystemRowsAndPushesDownSupervisorId() throws Exception
+  {
+    final TaskMaster taskMaster = Mockito.mock(TaskMaster.class);
+    final SupervisorManager manager = Mockito.mock(SupervisorManager.class);
+    final SupervisorSpec supervisorA = new NoopSupervisorSpec("supervisor-a", List.of("datasource-a"));
+    final SupervisorSpec supervisorB = new NoopSupervisorSpec("supervisor-b", List.of("datasource-b"));
+    Mockito.when(taskMaster.getSupervisorManager()).thenReturn(Optional.of(manager));
+    Mockito.when(manager.getSupervisorIds()).thenReturn(Set.of("supervisor-a", "supervisor-b"));
+    Mockito.when(manager.getSupervisorState("supervisor-a"))
+           .thenReturn(Optional.of(SupervisorStateManager.BasicState.RUNNING));
+    Mockito.when(manager.getSupervisorSpec("supervisor-a")).thenReturn(Optional.of(supervisorA));
+    Mockito.when(manager.getSupervisorSpec("supervisor-b")).thenReturn(Optional.of(supervisorB));
+    final SupervisorsTableDataProvider provider = new SupervisorsTableDataProvider(
+        taskMaster,
+        TestHelper.makeJsonMapper()
+    );
+    final List<DimFilter> filters = List.of(
+        new SelectorDimFilter("supervisor_id", "supervisor-a", null)
+    );
+
+    final List<Object[]> rows = toList(provider.getRows(filters, Mockito.mock(AuthenticationResult.class)));
+
+    Assertions.assertEquals(1, rows.size());
+    Assertions.assertArrayEquals(
+        new Object[]{
+            "supervisor-a",
+            "datasource-a",
+            "RUNNING",
+            "RUNNING",
+            1L,
+            "noop",
+            "noop",
+            0L,
+            TestHelper.makeJsonMapper().writeValueAsString(supervisorA)
+        },
+        rows.get(0)
+    );
+    Mockito.verify(manager, Mockito.never()).getSupervisorState("supervisor-b");
+  }
+
+  @Test
+  public void testRejectsRowsOnStandbyOverlord()
+  {
+    final TaskMaster taskMaster = Mockito.mock(TaskMaster.class);
+    Mockito.when(taskMaster.getSupervisorManager()).thenReturn(Optional.absent());
+    final SupervisorsTableDataProvider provider = new SupervisorsTableDataProvider(
+        taskMaster,
+        TestHelper.makeJsonMapper()
+    );
+
+    Assertions.assertThrows(
+        SystemTableNotLeaderException.class,
+        () -> provider.getRows(Collections.emptyList(), Mockito.mock(AuthenticationResult.class))
+    );
+  }
+
+  private static List<Object[]> toList(final Iterable<Object[]> rows)
+  {
+    final List<Object[]> list = new ArrayList<>();
+    rows.forEach(list::add);
+    return list;
+  }
+}

--- a/server/src/main/java/org/apache/druid/server/system/module/SystemTableModule.java
+++ b/server/src/main/java/org/apache/druid/server/system/module/SystemTableModule.java
@@ -27,6 +27,7 @@ import org.apache.druid.guice.LazySingleton;
 import org.apache.druid.query.SystemTableDataSource;
 import org.apache.druid.server.system.table.ServerPropertiesTableDataProvider;
 import org.apache.druid.server.system.table.ServerPropertiesTableDescriptor;
+import org.apache.druid.server.system.table.SupervisorTableDescriptor;
 import org.apache.druid.server.system.table.SystemTableDataProvider;
 import org.apache.druid.server.system.table.SystemTableDescriptor;
 import org.apache.druid.server.system.table.TaskTableDescriptor;
@@ -34,8 +35,8 @@ import org.apache.druid.server.system.table.TaskTableDescriptor;
 /**
  * Registers native system-table routing and the node-local server-properties supplier.
  *
- * <p>Table-specific integrations, such as the task supplier in indexing-service, contribute their own entries to the
- * native system-table multibinders.</p>
+ * <p>Table-specific integrations in indexing-service, such as the task and supervisor providers, contribute their
+ * own entries to the native system-table multibinders.</p>
  */
 public class SystemTableModule implements Module
 {
@@ -52,6 +53,8 @@ public class SystemTableModule implements Module
                     .toInstance(new ServerPropertiesTableDescriptor());
     descriptorBinder.addBinding(TaskTableDescriptor.TABLE_NAME)
                     .toInstance(new TaskTableDescriptor());
+    descriptorBinder.addBinding(SupervisorTableDescriptor.TABLE_NAME)
+                    .toInstance(new SupervisorTableDescriptor());
 
     final MapBinder<String, SystemTableDataProvider> dataProviderBinder = MapBinder.newMapBinder(binder, String.class, SystemTableDataProvider.class);
     dataProviderBinder.addBinding(ServerPropertiesTableDescriptor.TABLE_NAME)

--- a/server/src/main/java/org/apache/druid/server/system/table/SupervisorTableDescriptor.java
+++ b/server/src/main/java/org/apache/druid/server/system/table/SupervisorTableDescriptor.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.server.system.table;
+
+import org.apache.druid.discovery.NodeRole;
+import org.apache.druid.segment.column.ColumnType;
+import org.apache.druid.segment.column.RowSignature;
+import org.apache.druid.server.security.AuthenticationResult;
+import org.apache.druid.server.security.AuthorizationUtils;
+import org.apache.druid.server.security.AuthorizerMapper;
+
+import java.util.Collections;
+import java.util.Set;
+
+/** Descriptor for the native {@code sys.supervisors} table. */
+public class SupervisorTableDescriptor implements SystemTableDescriptor
+{
+  public static final String TABLE_NAME = "supervisors";
+  public static final RowSignature ROW_SIGNATURE = RowSignature
+      .builder()
+      .add("supervisor_id", ColumnType.STRING)
+      .add("datasource", ColumnType.STRING)
+      .add("state", ColumnType.STRING)
+      .add("detailed_state", ColumnType.STRING)
+      .add("healthy", ColumnType.LONG)
+      .add("type", ColumnType.STRING)
+      .add("source", ColumnType.STRING)
+      .add("suspended", ColumnType.LONG)
+      .add("spec", ColumnType.STRING)
+      .build();
+
+  private static final Set<NodeRole> NODE_ROLES = Set.of(NodeRole.OVERLORD);
+  private static final int DATASOURCE_COLUMN = ROW_SIGNATURE.indexOf("datasource");
+  private static final SystemTableRowAuthorizer ROW_AUTHORIZER = new SystemTableRowAuthorizer()
+  {
+    @Override
+    public Iterable<Object[]> filterAuthorizedRows(
+        final Iterable<Object[]> rows,
+        final AuthenticationResult authenticationResult,
+        final AuthorizerMapper authorizerMapper
+    )
+    {
+      return AuthorizationUtils.filterAuthorizedResources(
+          authenticationResult,
+          rows,
+          row -> Collections.singletonList(
+              AuthorizationUtils.DATASOURCE_READ_RA_GENERATOR.apply((String) row[DATASOURCE_COLUMN])
+          ),
+          authorizerMapper
+      );
+    }
+  };
+
+  @Override
+  public String getTableName()
+  {
+    return TABLE_NAME;
+  }
+
+  @Override
+  public Set<NodeRole> getNodeRoles()
+  {
+    return NODE_ROLES;
+  }
+
+  @Override
+  public SystemTableRoutingMode getRoutingMode()
+  {
+    return SystemTableRoutingMode.LEADER_ONLY;
+  }
+
+  @Override
+  public RowSignature getRowSignature()
+  {
+    return ROW_SIGNATURE;
+  }
+
+  @Override
+  public SystemTableRowAuthorizer getRowAuthorizer()
+  {
+    return ROW_AUTHORIZER;
+  }
+}

--- a/server/src/test/java/org/apache/druid/server/system/table/SupervisorTableDescriptorTest.java
+++ b/server/src/test/java/org/apache/druid/server/system/table/SupervisorTableDescriptorTest.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.server.system.table;
+
+import org.apache.druid.discovery.NodeRole;
+import org.apache.druid.server.security.Access;
+import org.apache.druid.server.security.AuthenticationResult;
+import org.apache.druid.server.security.AuthorizerMapper;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class SupervisorTableDescriptorTest
+{
+  @Test
+  public void testDescriptorMetadata()
+  {
+    final SupervisorTableDescriptor descriptor = new SupervisorTableDescriptor();
+
+    Assertions.assertEquals("supervisors", descriptor.getTableName());
+    Assertions.assertEquals(Set.of(NodeRole.OVERLORD), descriptor.getNodeRoles());
+    Assertions.assertEquals(SystemTableRoutingMode.LEADER_ONLY, descriptor.getRoutingMode());
+    Assertions.assertEquals(SupervisorTableDescriptor.ROW_SIGNATURE, descriptor.getRowSignature());
+  }
+
+  @Test
+  public void testAuthorizesRowsByDatasource()
+  {
+    final SupervisorTableDescriptor descriptor = new SupervisorTableDescriptor();
+    final AuthenticationResult authenticationResult = new AuthenticationResult("user", "test", null, null);
+    final AuthorizerMapper authorizerMapper = new AuthorizerMapper(
+        Map.of(
+            "test",
+            (authentication, resource, action) -> "datasource-a".equals(resource.getName())
+                                                   ? Access.OK
+                                                   : Access.deny("denied")
+        )
+    );
+    final Object[] authorizedRow = row("supervisor-a", "datasource-a");
+    final Object[] deniedRow = row("supervisor-b", "datasource-b");
+
+    final List<Object[]> filteredRows = new ArrayList<>();
+    descriptor.getRowAuthorizer()
+              .filterAuthorizedRows(List.of(authorizedRow, deniedRow), authenticationResult, authorizerMapper)
+              .forEach(filteredRows::add);
+
+    Assertions.assertEquals(1, filteredRows.size());
+    Assertions.assertSame(authorizedRow, filteredRows.get(0));
+  }
+
+  private static Object[] row(final String supervisorId, final String datasource)
+  {
+    final Object[] row = new Object[SupervisorTableDescriptor.ROW_SIGNATURE.size()];
+    row[SupervisorTableDescriptor.ROW_SIGNATURE.indexOf("supervisor_id")] = supervisorId;
+    row[SupervisorTableDescriptor.ROW_SIGNATURE.indexOf("datasource")] = datasource;
+    return row;
+  }
+}

--- a/services/src/main/java/org/apache/druid/cli/CliOverlord.java
+++ b/services/src/main/java/org/apache/druid/cli/CliOverlord.java
@@ -110,6 +110,7 @@ import org.apache.druid.indexing.overlord.sampler.SamplerModule;
 import org.apache.druid.indexing.overlord.setup.WorkerBehaviorConfig;
 import org.apache.druid.indexing.overlord.supervisor.SupervisorManager;
 import org.apache.druid.indexing.overlord.supervisor.SupervisorResource;
+import org.apache.druid.indexing.overlord.supervisor.SupervisorsTableDataProvider;
 import org.apache.druid.indexing.overlord.task.TasksTableDataProvider;
 import org.apache.druid.indexing.scheduledbatch.ScheduledBatchTaskManager;
 import org.apache.druid.indexing.worker.config.WorkerConfig;
@@ -144,6 +145,7 @@ import org.apache.druid.server.security.AuthConfig;
 import org.apache.druid.server.security.AuthenticationUtils;
 import org.apache.druid.server.security.Authenticator;
 import org.apache.druid.server.security.AuthenticatorMapper;
+import org.apache.druid.server.system.table.SupervisorTableDescriptor;
 import org.apache.druid.server.system.table.SystemTableDataProvider;
 import org.apache.druid.server.system.table.TaskTableDescriptor;
 import org.apache.druid.storage.local.LocalTmpStorageConfig;
@@ -226,6 +228,9 @@ public class CliOverlord extends ServerRunnable
             );
             dataProviderBinder.addBinding(TaskTableDescriptor.TABLE_NAME)
                               .to(TasksTableDataProvider.class)
+                              .in(LazySingleton.class);
+            dataProviderBinder.addBinding(SupervisorTableDescriptor.TABLE_NAME)
+                              .to(SupervisorsTableDataProvider.class)
                               .in(LazySingleton.class);
 
             validateCentralizedDatasourceSchemaConfig(properties);

--- a/sql/src/main/java/org/apache/druid/sql/calcite/schema/NativeSupervisorsTable.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/schema/NativeSupervisorsTable.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.sql.calcite.schema;
+
+import org.apache.calcite.plan.RelOptTable;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.logical.LogicalTableScan;
+import org.apache.calcite.schema.Schema;
+import org.apache.druid.query.DataSource;
+import org.apache.druid.query.SystemTableDataSource;
+import org.apache.druid.server.system.table.SupervisorTableDescriptor;
+import org.apache.druid.sql.calcite.table.DruidTable;
+
+/** Native-query representation of {@code sys.supervisors}. */
+class NativeSupervisorsTable extends DruidTable
+{
+  private static final DataSource DATA_SOURCE = new SystemTableDataSource(
+      SupervisorTableDescriptor.TABLE_NAME
+  );
+
+  NativeSupervisorsTable()
+  {
+    super(SupervisorTableDescriptor.ROW_SIGNATURE);
+  }
+
+  @Override
+  public DataSource getDataSource()
+  {
+    return DATA_SOURCE;
+  }
+
+  @Override
+  public boolean isJoinable()
+  {
+    return false;
+  }
+
+  @Override
+  public boolean isBroadcast()
+  {
+    return false;
+  }
+
+  @Override
+  public Schema.TableType getJdbcTableType()
+  {
+    return Schema.TableType.SYSTEM_TABLE;
+  }
+
+  @Override
+  public RelNode toRel(final RelOptTable.ToRelContext context, final RelOptTable table)
+  {
+    return LogicalTableScan.create(context.getCluster(), table, context.getTableHints());
+  }
+}

--- a/sql/src/main/java/org/apache/druid/sql/calcite/schema/SystemSchema.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/schema/SystemSchema.java
@@ -108,7 +108,6 @@ public class SystemSchema extends AbstractTableSchema
   public static final String SEGMENTS_TABLE = "segments";
   public static final String SERVERS_TABLE = "servers";
   public static final String SERVER_SEGMENTS_TABLE = "server_segments";
-  public static final String SUPERVISOR_TABLE = SupervisorTableDescriptor.TABLE_NAME;
   public static final String QUERIES_TABLE = "queries";
 
   private static final Function<SegmentStatusInCluster, Iterable<ResourceAction>>

--- a/sql/src/main/java/org/apache/druid/sql/calcite/schema/SystemSchema.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/schema/SystemSchema.java
@@ -74,6 +74,7 @@ import org.apache.druid.server.security.ForbiddenException;
 import org.apache.druid.server.security.Resource;
 import org.apache.druid.server.security.ResourceAction;
 import org.apache.druid.server.security.ResourceType;
+import org.apache.druid.server.system.table.SupervisorTableDescriptor;
 import org.apache.druid.server.system.table.TaskTableDescriptor;
 import org.apache.druid.sql.calcite.planner.PlannerConfig;
 import org.apache.druid.sql.calcite.planner.PlannerContext;
@@ -107,7 +108,7 @@ public class SystemSchema extends AbstractTableSchema
   public static final String SEGMENTS_TABLE = "segments";
   public static final String SERVERS_TABLE = "servers";
   public static final String SERVER_SEGMENTS_TABLE = "server_segments";
-  public static final String SUPERVISOR_TABLE = "supervisors";
+  public static final String SUPERVISOR_TABLE = SupervisorTableDescriptor.TABLE_NAME;
   public static final String QUERIES_TABLE = "queries";
 
   private static final Function<SegmentStatusInCluster, Iterable<ResourceAction>>
@@ -225,19 +226,6 @@ public class SystemSchema extends AbstractTableSchema
       .add("segment_id", ColumnType.STRING)
       .build();
 
-  static final RowSignature SUPERVISOR_SIGNATURE = RowSignature
-      .builder()
-      .add("supervisor_id", ColumnType.STRING)
-      .add("datasource", ColumnType.STRING)
-      .add("state", ColumnType.STRING)
-      .add("detailed_state", ColumnType.STRING)
-      .add("healthy", ColumnType.LONG)
-      .add("type", ColumnType.STRING)
-      .add("source", ColumnType.STRING)
-      .add("suspended", ColumnType.LONG)
-      .add("spec", ColumnType.STRING)
-      .build();
-
   static final RowSignature QUERIES_SIGNATURE = RowSignature
       .builder()
       .add("id", ColumnType.STRING)
@@ -331,7 +319,11 @@ public class SystemSchema extends AbstractTableSchema
       );
       case SERVER_SEGMENTS_TABLE -> new ServerSegmentsTable(serverView, authorizerMapper, authenticationResult);
       case TaskTableDescriptor.TABLE_NAME -> new TasksTable(overlordClient, authorizerMapper, authenticationResult);
-      case SUPERVISOR_TABLE -> new SupervisorsTable(overlordClient, authorizerMapper, authenticationResult);
+      case SupervisorTableDescriptor.TABLE_NAME -> new SupervisorsTable(
+          overlordClient,
+          authorizerMapper,
+          authenticationResult
+      );
       case SystemServerPropertiesTable.TABLE_NAME -> new SystemServerPropertiesTable(
           druidNodeDiscoveryProvider,
           authorizerMapper,
@@ -1084,9 +1076,9 @@ public class SystemSchema extends AbstractTableSchema
   }
 
   /**
-   * This table contains a row per supervisor task.
+   * This table contains a row per supervisor.
    */
-  static class SupervisorsTable extends AbstractTable implements ScannableTable
+  static class SupervisorsTable extends AbstractTable implements ScannableTable, NativeSystemTable
   {
     private final OverlordClient overlordClient;
     private final AuthorizerMapper authorizerMapper;
@@ -1107,13 +1099,19 @@ public class SystemSchema extends AbstractTableSchema
     @Override
     public RelDataType getRowType(RelDataTypeFactory typeFactory)
     {
-      return RowSignatures.toRelDataType(SUPERVISOR_SIGNATURE, typeFactory);
+      return RowSignatures.toRelDataType(SupervisorTableDescriptor.ROW_SIGNATURE, typeFactory);
     }
 
     @Override
     public TableType getJdbcTableType()
     {
       return TableType.SYSTEM_TABLE;
+    }
+
+    @Override
+    public DruidTable asNativeTable()
+    {
+      return new NativeSupervisorsTable();
     }
 
     @Override

--- a/sql/src/main/java/org/apache/druid/sql/calcite/schema/SystemSchemaProvider.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/schema/SystemSchemaProvider.java
@@ -32,6 +32,7 @@ import org.apache.druid.java.util.http.client.HttpClient;
 import org.apache.druid.rpc.indexing.OverlordClient;
 import org.apache.druid.server.security.AuthenticationResult;
 import org.apache.druid.server.security.AuthorizerMapper;
+import org.apache.druid.server.system.table.SupervisorTableDescriptor;
 import org.apache.druid.server.system.table.TaskTableDescriptor;
 import org.apache.druid.sql.calcite.planner.PlannerConfig;
 import org.apache.druid.sql.http.SqlEngineRegistry;
@@ -96,7 +97,7 @@ public class SystemSchemaProvider implements SchemaProvider
     allTableNames.add(SystemSchema.SERVERS_TABLE);
     allTableNames.add(SystemSchema.SERVER_SEGMENTS_TABLE);
     allTableNames.add(TaskTableDescriptor.TABLE_NAME);
-    allTableNames.add(SystemSchema.SUPERVISOR_TABLE);
+    allTableNames.add(SupervisorTableDescriptor.TABLE_NAME);
     allTableNames.add(SystemServerPropertiesTable.TABLE_NAME);
 
     if (plannerConfig.isEnableSysQueriesTable()) {

--- a/sql/src/test/java/org/apache/druid/sql/calcite/schema/SystemSchemaTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/schema/SystemSchemaTest.java
@@ -107,6 +107,7 @@ import org.apache.druid.server.security.Authorizer;
 import org.apache.druid.server.security.AuthorizerMapper;
 import org.apache.druid.server.security.NoopEscalator;
 import org.apache.druid.server.security.ResourceType;
+import org.apache.druid.server.system.table.SupervisorTableDescriptor;
 import org.apache.druid.server.system.table.TaskTableDescriptor;
 import org.apache.druid.sql.calcite.planner.PlannerConfig;
 import org.apache.druid.sql.calcite.run.SqlEngine;
@@ -1604,7 +1605,7 @@ public class SystemSchemaTest extends CalciteTestBase
     );
 
     // Verify value types.
-    verifyTypes(rows, SystemSchema.SUPERVISOR_SIGNATURE);
+    verifyTypes(rows, SupervisorTableDescriptor.ROW_SIGNATURE);
   }
 
   @Test
@@ -1657,7 +1658,7 @@ public class SystemSchemaTest extends CalciteTestBase
     // TODO: If needed, verify the first row here
 
     // TODO: Verify value types.
-    // verifyTypes(rows, SystemSchema.SUPERVISOR_SIGNATURE);
+    // verifyTypes(rows, SupervisorTableDescriptor.ROW_SIGNATURE);
   }
 
   @Test

--- a/sql/src/test/java/org/apache/druid/sql/calcite/schema/SystemTableDataProviderTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/schema/SystemTableDataProviderTest.java
@@ -42,6 +42,12 @@ public class SystemTableDataProviderTest
     Assertions.assertFalse(tasks.isBroadcast());
     Assertions.assertEquals(Schema.TableType.SYSTEM_TABLE, tasks.getJdbcTableType());
 
+    final NativeSupervisorsTable supervisors = new NativeSupervisorsTable();
+    Assertions.assertEquals("supervisors", ((SystemTableDataSource) supervisors.getDataSource()).getTable());
+    Assertions.assertFalse(supervisors.isJoinable());
+    Assertions.assertFalse(supervisors.isBroadcast());
+    Assertions.assertEquals(Schema.TableType.SYSTEM_TABLE, supervisors.getJdbcTableType());
+
     final NativeServerPropertiesTable serverProperties = new NativeServerPropertiesTable();
     Assertions.assertEquals(
         "server_properties",


### PR DESCRIPTION
### Description

Adds native-query support for `sys.supervisors` on top of the generic native system-table framework introduced by the target branch.

The change:

- defines the table signature, leader-Overlord routing, and datasource row authorization in a shared descriptor;
- registers an Overlord-local data provider and exposes the existing Calcite system table as a native `SystemTableDataSource` when the native system-table query context is selected;
- reuses one status mapper for the existing supervisor REST response and native rows, preserving the established column semantics;
- pushes exact `supervisor_id` selector, equality, `IN`, typed `IN`, and same-column `OR` filters into the provider so unrelated supervisor state and specifications are not constructed or serialized;
- keeps the existing bindable implementation as the fallback path; and
- documents the newly supported table.

The provider deliberately reads the leader Overlord's in-memory `SupervisorManager`, rather than adding another HTTP endpoint or querying metadata storage. Native aggregation remains in the existing distributed native query pipeline.

#### Release note

SQL queries over `sys.supervisors` can use the native engine when native system-table execution is selected in query context. This enables native operators such as distinct aggregation while retaining the existing bindable fallback.

##### Key changed/added classes in this PR

- `SystemSupervisorsTableDescriptor`
- `SystemSupervisorsTableDataProvider`
- `NativeSupervisorsTable`
- `SupervisorStatusMapper`
- `NativeSysSupervisorsQueryTest`

### Testing

- Targeted unit tests for the descriptor, provider, schema integration, existing REST resource behavior, and Overlord bindings (67 selected tests)
- Embedded end-to-end native SQL tests in coupled and decoupled planning modes, covering filter pushdown, grouping, `COUNT(DISTINCT ...)`, and `SUM` (4 tests)
- `CliOverlordTest` (2 tests)
- Checkstyle, PMD, SpotBugs, and forbidden-APIs checks for all affected modules

This PR has:

- [x] been self-reviewed.
- [x] added documentation for new or modified features or behaviors.
- [x] a release note entry in the PR description.
- [x] added Javadocs for the new classes and non-obvious behavior.
- [x] added comments explaining non-obvious intent.
- [x] added unit tests or modified existing tests to cover new code paths.
- [x] added integration tests.
